### PR TITLE
🐛 Create the output file before write

### DIFF
--- a/lib/env2dart.dart
+++ b/lib/env2dart.dart
@@ -219,6 +219,9 @@ void envgen({
     output = '$output.dart';
   }
   final outputFile = File(output);
+  if (!outputFile.existsSync()) {
+    outputFile.createSync(recursive: true);
+  }
   'output: ${outputFile.path}'.$info(tag: 'env2dart');
   outputFile.writeAsStringSync(code);
   'Generation successful, took ${sw.elapsed.inMilliseconds} milliseconds.'


### PR DESCRIPTION
If the output file will be generated in `lib/constants` and the directory does not exist, the generation will fail.

<details>
<summary>Before</summary>

```console
dart.exe --enable-asserts path/to/env2dart.dart -a prod -o lib/constants/env.dart
 I  13:49:12.820 env2dart Generating, please wait.
 I  13:49:12.884 env2dart load .env

KEY          | VALUE                                                                                  
======================================================================================================
API_BASE_URL | ""                                                     
BOT_KEY      | ""                                                               
BOT_URL      | ""


 I  13:49:12.885 env2dart load .env.dev

KEY          | VALUE                                     
=========================================================
API_BASE_URL | ""


 I  13:49:12.885 env2dart load .env.prod

KEY          | VALUE                             
=================================================
API_BASE_URL | ""


Unhandled exception:
PathNotFoundException: Cannot open file, path = 'lib/constants/env.dart' (OS Error: The system cannot find the path specified.
, errno = 3)
#0      _File.throwIfError (dart:io/file_impl.dart:675:7)
#1      _File.openSync (dart:io/file_impl.dart:490:5)
#2      _File.writeAsBytesSync (dart:io/file_impl.dart:644:31)
#3      _File.writeAsStringSync (dart:io/file_impl.dart:668:5)
#4      envgen (package:env2dart/env2dart.dart:226:14)
#5      parseAndGen (package:env2dart/env2dart.dart:661:3)
#6      main (file:///X:/Coding/Garages/Flutter/env2dart/bin/env2dart.dart:3:38)
#7      _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:294:33)
#8      _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:189:12)
 I  13:49:13.073 env2dart output: lib/constants/env.dart

Process finished with exit code 255
```
</details>

<details>
<summary>After</summary>

```console
dart.exe --enable-asserts path/to/env2dart.dart -a prod -o lib/constants/env.dart
 I  13:51:07.504 env2dart Generating, please wait.
 I  13:51:07.567 env2dart load .env

KEY          | VALUE                                                                                  
======================================================================================================
API_BASE_URL | ""                                                     
BOT_KEY      | ""                                                               
BOT_URL      | ""


 I  13:51:07.567 env2dart load .env.dev

KEY          | VALUE                                     
=========================================================
API_BASE_URL | ""


 I  13:51:07.568 env2dart load .env.prod

KEY          | VALUE                             
=================================================
API_BASE_URL | ""


 I  13:51:07.752 env2dart output: lib/constants/env.dart
 I  13:51:07.754 env2dart Generation successful, took 248 milliseconds.

Process finished with exit code 0
```
</details>